### PR TITLE
Update puppet-modules.sh

### DIFF
--- a/scripts/puppet-modules.sh
+++ b/scripts/puppet-modules.sh
@@ -3,5 +3,5 @@
 puppet module install --modulepath '$basemodulepath' puppet-zabbix
 
 # for some reasons gpg key is not imported by puppet module
-rpm --import http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-A14FE591
+rpm --import http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX
 


### PR DESCRIPTION
Change will fix the error 
Error: Execution of '/bin/yum -d 0 -e 0 -y install zabbix-server-pgsql' returned 1: warning: /var/cache/yum/x86_64/7/Zabbix_nonsupported_7_x86_64/packages/fping-3.10-1.el7.x86_64.rpm: Header V4 DSA/SHA1 Signature, key ID 79ea5ed4: NOKEY